### PR TITLE
Update completion to work with racer 2.0

### DIFF
--- a/rplugin/python3/deoplete/sources/rust.py
+++ b/rplugin/python3/deoplete/sources/rust.py
@@ -75,7 +75,7 @@ class Source(Base):
                 'complete',
                 str(line),
                 str(column),
-                os.path.dirname(content.name),
+                content.name,
                 buf.name
             ]
 


### PR DESCRIPTION
Instead of the directory where the file resides, Racer 2.0 expects the third argument of `complete` to be the path to the original file. This patch performs that change.