### PR TITLE
Set the `info` field for candidate.

### DIFF
--- a/rplugin/python3/deoplete/sources/rust.py
+++ b/rplugin/python3/deoplete/sources/rust.py
@@ -55,6 +55,7 @@ class Source(Base):
                 'word': tokens[0],
                 'kind': tokens[4],
                 'menu': tokens[5],
+                'info': ','.join(tokens[5:]),
                 'dup': 1,
             }
             candidates.append(candidate)


### PR DESCRIPTION
If the function has more than 1 parameters, the `menu` field will only
show first parameter. Set the whole thing to the `info` filed, user can
see the whole signature of the function in the preview window.
Here's a screenshot:
![](https://ws4.sinaimg.cn/large/006tKfTcly1fh1a1af922j314o0ksk0i.jpg)