### PR TITLE
deoplete-rust: add shorthand home (~) expansion

### DIFF
--- a/plugin/deoplete-rust.vim
+++ b/plugin/deoplete-rust.vim
@@ -7,10 +7,10 @@ let s:save_cpoptions = &cpoptions
 set cpoptions&vim
 
 let g:deoplete#sources#rust#racer_binary=
-    \ get(g:, 'deoplete#sources#rust#racer_binary', '')
+    \ expand(get(g:, 'deoplete#sources#rust#racer_binary', ''))
 
 let g:deoplete#sources#rust#rust_source_path=
-    \ get(g:, 'deoplete#sources#rust#rust_source_path', '')
+    \ expand(get(g:, 'deoplete#sources#rust#rust_source_path', ''))
 
 let g:deoplete#sources#rust#documentation_max_height=
     \ get(g:, 'deoplete#sources#rust#documentation_max_height', 20)


### PR DESCRIPTION
Previously, only absolute paths were required, this change allows to use
paths relative to the home directory shorthand command (~)

Fixes: https://github.com/sebastianmarkow/deoplete-rust/issues/4

Signed-off-by: Antonio Gutierrez <chibby0ne@gmail.com>